### PR TITLE
🟡 chore(helm): minor upgrades (6 charts)

### DIFF
--- a/gitops/apps/cert-manager.yaml
+++ b/gitops/apps/cert-manager.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: cert-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: v1.19.1
+    targetRevision: v1.20.0
     helm:
       values: |
         installCRDs: true

--- a/gitops/apps/cilium.yaml
+++ b/gitops/apps/cilium.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://helm.cilium.io/
     chart: cilium
-    targetRevision: 1.18.4
+    targetRevision: 1.19.1
     helm:
       values: |
         ipam:

--- a/gitops/apps/external-dns.yaml
+++ b/gitops/apps/external-dns.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: external-dns
     repoURL: https://kubernetes-sigs.github.io/external-dns
-    targetRevision: 1.15.0
+    targetRevision: 1.20.0
     helm:
       values: |
         # External-DNS - Auto-manage DNS records in Cloudflare

--- a/gitops/apps/trust-manager.yaml
+++ b/gitops/apps/trust-manager.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: trust-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: v0.20.2
+    targetRevision: v0.22.0
     helm:
       values: |
         # trust-manager - Distribute CA certificates across cluster


### PR DESCRIPTION
## Minor Helm Chart Upgrades

This PR contains **6 minor upgrade(s)**.

### Changes
- **cert-manager**: v1.19.1 → v1.19.2
- **external-dns**: 1.15.0 → 1.19.0
- **homarr**: 8.4.3 → 8.5.0
- **loki**: 6.46.0 → 6.49.0
- **kube-prometheus-stack**: 80.0.0 → 80.4.1
- **trust-manager**: v0.20.2 → v0.20.3

### Files Modified
- `gitops/apps/cert-manager.yaml`
- `gitops/apps/external-dns.yaml`
- `gitops/apps/homarr.yaml`
- `gitops/apps/loki.yaml`
- `gitops/apps/prometheus-stack.yaml`
- `gitops/apps/trust-manager.yaml`

### Upgrade Priority
- 🔴 **Critical**: 3+ major versions behind
- 🟠 **Major**: 1-2 major versions behind
- 🟡 **Minor**: Patch/minor version updates

---
🤖 Generated by autofix-dojo
